### PR TITLE
Use <ol> and <li value="?"> for crosswords instead of <dl>, <dt>, <dd>.

### DIFF
--- a/puzzle-js-demo.html
+++ b/puzzle-js-demo.html
@@ -61,25 +61,28 @@
                     "....@"
                  ]   
                 }
-
-                <dl class="crossword-clues across">
-                    <dt>Across</dt>
-                    <dd>Each entry of this puzzle</dd>
-                    <dd>The third clue number in this grid</dd>
-                    <dd>A greeting</dd>
-                    <dd>A common article</dd>
-                    <dd>Components of a list</dd>
-                    <dd>Neural ____</dd>
-                </dl>
-                <dl class="crossword-clues down">
-                    <dt>Down</dt>
-                    <dd>Most common color in this grid</dd>
-                    <dd>A Boolean operator</dd>
-                    <dd>Quantities of paper</dd>
-                    <dd>Where bears live</dd>
-                    <dd>Flimsy</dd>
-                    <dd>It phoned home</dd>
-                </dl>
+                <div class="crossword-clues across">
+                    <h2>Across</h2>
+                    <ol>
+                        <li>Each entry of this puzzle</li>
+                        <li>The third clue number in this grid</li>
+                        <li>A greeting</li>
+                        <li>A common article</li>
+                        <li>Components of a list</li>
+                        <li>Neural ____</li>
+                    </ol>
+                </div>
+                <div class="crossword-clues down">
+                    <h2>Down</h2>
+                    <ol>
+                        <li>Most common color in this grid</li>
+                        <li>A Boolean operator</li>
+                        <li>Quantities of paper</li>
+                        <li>Where bears live</li>
+                        <li>Flimsy</li>
+                        <li>It phoned home</li>
+                    </ol>
+                </div>
             </div>
 
             <div>Barred with clues</div>
@@ -98,20 +101,24 @@
                  ]  
                 }
 
-                <dl class="crossword-clues across">
-                    <dt>Across</dt>
-                    <dd>Sticky stuff</dd>
-                    <dd>Thought</dd>
-                    <dd>Crime film genre</dd>
-                    <dd>A state of matter</dd>
-                </dl>
-                <dl class="crossword-clues down">
-                    <dt>Down</dt>
-                    <dd>Small, like this puzzle</dd>
-                    <dd>Outdoor equipment retailer</dd>
-                    <dd>This puzzle has a few</dd>
-                    <dd>Family pet, often</dd>
-                </dl>
+                <div class="crossword-clues across">
+                    <h2>Across</h2>
+                    <ol>
+                        <li>Sticky stuff</li>
+                        <li>Thought</li>
+                        <li>Crime film genre</li>
+                        <li>A state of matter</li>
+                    </ol>
+                </div>
+                <div class="crossword-clues down">
+                    <h2>Down</h2>
+                    <ol>
+                      <li>Small, like this puzzle</li>
+                      <li>Outdoor equipment retailer</li>
+                      <li>This puzzle has a few</li>
+                      <li>Family pet, often</li>
+                    </ol>
+                </div>
             </div>
 
             <div>Mini sudoku</div>

--- a/puzzle.css
+++ b/puzzle.css
@@ -113,24 +113,11 @@
     vertical-align: top;
     margin-block-start: 0;
     margin-block-end: 0;
-    padding-left: 20px;
-    text-indent: -20px;
 }
-.crossword-clues dt {
-    font-weight: bold;
-}
-.crossword-clues dd {
-    margin: 0;
-    padding: 2px;
-}
-.crossword-clues dd:before {
-    content: attr(data-across-cluenumber)attr(data-down-cluenumber) '. ';
-    padding: 2px;
-}
-.crossword-clues dd.strikethrough {
+.crossword-clues li.strikethrough {
     text-decoration: line-through;
 }
-.crossword-clues dd:hover, .crossword-clues dd.marked, .crossword-clues dd:hover::before, .crossword-clues dd.marked::before {
+.crossword-clues li:hover, .crossword-clues li.marked, .crossword-clues li:hover::before, .crossword-clues li.marked::before {
     background-color: lightblue;
 }
 

--- a/puzzle.js
+++ b/puzzle.js
@@ -478,13 +478,13 @@ function PuzzleEntry(p) {
         var acrosscluenumber = e.currentTarget.parentElement.getAttribute("data-across-cluenumber");
         var downcluenumber = e.currentTarget.parentElement.getAttribute("data-down-cluenumber");
         if (acrosscluenumber) {
-            this.container.querySelector("dd[data-across-cluenumber='" + acrosscluenumber + "']").classList.add("marked");
+            this.container.querySelector("li[data-across-cluenumber='" + acrosscluenumber + "']").classList.add("marked");
             if (this.dx !== 0) {
                 this.container.querySelectorAll("td[data-across-cluenumber='" + acrosscluenumber + "']").forEach(td => { td.classList.add("marked"); });
             }
         }
         if (downcluenumber) {
-            this.container.querySelector("dd[data-down-cluenumber='" + downcluenumber + "']").classList.add("marked");
+            this.container.querySelector("li[data-down-cluenumber='" + downcluenumber + "']").classList.add("marked");
             if (this.dy !== 0) {
                 this.container.querySelectorAll("td[data-down-cluenumber='" + downcluenumber + "']").forEach(td => { td.classList.add("marked"); });
             }
@@ -495,13 +495,13 @@ function PuzzleEntry(p) {
         var acrosscluenumber = e.currentTarget.parentElement.getAttribute("data-across-cluenumber");
         var downcluenumber = e.currentTarget.parentElement.getAttribute("data-down-cluenumber");
         if (acrosscluenumber) {
-            this.container.querySelector("dd[data-across-cluenumber='" + acrosscluenumber + "']").classList.remove("marked");
+            this.container.querySelector("li[data-across-cluenumber='" + acrosscluenumber + "']").classList.remove("marked");
             if (this.dx !== 0) {
                 this.container.querySelectorAll("td[data-across-cluenumber='" + acrosscluenumber + "']").forEach(td => { td.classList.remove("marked"); });
             }
         }
         if (downcluenumber) {
-            this.container.querySelector("dd[data-down-cluenumber='" + downcluenumber + "']").classList.remove("marked");
+            this.container.querySelector("li[data-down-cluenumber='" + downcluenumber + "']").classList.remove("marked");
             if (this.dy !== 0) {
                 this.container.querySelectorAll("td[data-down-cluenumber='" + downcluenumber + "']").forEach(td => { td.classList.remove("marked"); });
             }
@@ -652,9 +652,9 @@ function PuzzleEntry(p) {
     var clueNum = 0;
     var extractNum = 0;
 
-    var acrossClues = this.container.querySelectorAll(".crossword-clues.across dd");
+    var acrossClues = this.container.querySelectorAll(".crossword-clues.across li");
     var acrossClueIndex = 0;
-    var downClues = this.container.querySelectorAll(".crossword-clues.down dd");
+    var downClues = this.container.querySelectorAll(".crossword-clues.down li");
     var downClueIndex = 0;
 
     var regularRowBorder = 0;
@@ -793,8 +793,16 @@ function PuzzleEntry(p) {
 
                     if (acrossClue) { td.setAttribute("data-across-cluenumber", clueRealNum); }
                     if (downClue) { td.setAttribute("data-down-cluenumber", clueRealNum); }
-                    if (acrossClue && acrossClues[acrossClueIndex]) { acrossClues[acrossClueIndex++].setAttribute("data-across-cluenumber", clueRealNum); }
-                    if (downClue && downClues[downClueIndex]) { downClues[downClueIndex++].setAttribute("data-down-cluenumber", clueRealNum); }
+                    if (acrossClue && acrossClues[acrossClueIndex]) {
+                      acrossClues[acrossClueIndex].setAttribute("data-across-cluenumber", clueRealNum);
+                      acrossClues[acrossClueIndex].setAttribute("value", clueRealNum);
+                      acrossClueIndex++;
+                    }
+                    if (downClue && downClues[downClueIndex]) {
+                      downClues[downClueIndex].setAttribute("data-down-cluenumber", clueRealNum);
+                      downClues[downClueIndex].setAttribute("value", clueRealNum);
+                      downClueIndex++;
+                    }
 
                     var clue = document.createElement("div");
                     clue.classList.add("clue");
@@ -802,7 +810,7 @@ function PuzzleEntry(p) {
                     td.appendChild(clue);
                 }
                 if (!acrossClue && c > 0 && shape[r][c-1] != '@' && !(edgeCode & 4)) { td.setAttribute("data-across-cluenumber", tr.children[c-1].getAttribute("data-across-cluenumber")); }
-                if (!downClue && r > 0 && shape[r-1][1] != '@' && !(edgeCode & 1)) { td.setAttribute("data-down-cluenumber", table.children[r-1].children[c].getAttribute("data-down-cluenumber")); }
+                if (!downClue && r > 0 && shape[r-1][c] != '@' && !(edgeCode & 1)) { td.setAttribute("data-down-cluenumber", table.children[r-1].children[c].getAttribute("data-down-cluenumber")); }
             }
 
             if (this.fillClasses) {
@@ -834,7 +842,7 @@ function PuzzleEntry(p) {
 
     this.container.insertBefore(table, this.container.firstChild);
 
-    this.container.querySelectorAll(".crossword-clues dd").forEach((clue) => {
+    this.container.querySelectorAll(".crossword-clues li").forEach((clue) => {
         clue.addEventListener("mouseenter", e => { this.clueMouseEnter(e); });
         clue.addEventListener("mouseleave", e => { this.clueMouseLeave(e); });
         clue.addEventListener("click", e => { this.clueClick(e); });


### PR DESCRIPTION
Also fix a typo in data-down-cluenumber generation.

- Better HTML semantics for accessibility.
- Better clipboard support (when used with copyjack).