### PR TITLE
Set cell size with a CSS variable

### DIFF
--- a/demos/apples-to-apples/index.html
+++ b/demos/apples-to-apples/index.html
@@ -9,8 +9,8 @@
     <link rel="stylesheet" href="../../puzzlejs/puzzle.css">
     <script type="text/javascript" src="../../puzzlejs/puzzle.js"></script>
     <style>
-        .apples-to-apples { min-width: 800px; }
-        .apples-to-apples .cell { width: 25px; height: 25px; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 12px; text-shadow: none; }
+        .apples-to-apples { min-width: 800px; --cell-size: 25px; }
+        .apples-to-apples .cell { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 12px; text-shadow: none; }
         .apples-to-apples .cell.golden-delicious { background-color: #ffffb5; }
         .apples-to-apples .cell.granny-smith { background-color: #bce292; }
         .apples-to-apples .cell.fuji { background-color: #b20000; color: white; }
@@ -26,7 +26,8 @@
 
         @media print {
             .content-div p { font-size: 14px; }
-            .apples-to-apples .cell { width: 20px; height: 20px; font-size: 10px; }
+            .apples-to-apples { --cell-size: 20px; }
+            .apples-to-apples .cell { font-size: 10px; }
         }
     </style>
 </head>

--- a/demos/apples-to-apples/index.html
+++ b/demos/apples-to-apples/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../../puzzlejs/puzzle.css">
     <script type="text/javascript" src="../../puzzlejs/puzzle.js"></script>
     <style>
-        .apples-to-apples { min-width: 800px; --cell-size: 25px; }
+        .apples-to-apples { min-width: 800px; --puzzle-cell-size: 25px; }
         .apples-to-apples .cell { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 12px; text-shadow: none; }
         .apples-to-apples .cell.golden-delicious { background-color: #ffffb5; }
         .apples-to-apples .cell.granny-smith { background-color: #bce292; }
@@ -26,7 +26,7 @@
 
         @media print {
             .content-div p { font-size: 14px; }
-            .apples-to-apples { --cell-size: 20px; }
+            .apples-to-apples { --puzzle-cell-size: 20px; }
             .apples-to-apples .cell { font-size: 10px; }
         }
     </style>

--- a/demos/pictionary/index.html
+++ b/demos/pictionary/index.html
@@ -18,7 +18,7 @@
         .card { width: 300px; border: 1px solid black; border-radius: 10px 10px; display: flex; flex-direction: column; align-items: center; }
         .category .puzzle-entry { margin: 5px; }
         .puzzle-entry table { margin: 0px; }
-        .puzzle-entry { --cell-size: 30px; }
+        .puzzle-entry { --puzzle-cell-size: 30px; }
         .puzzle-entry .cell { font-size: 20px; }
         .puzzle-entry .cell use { stroke: #00000080; }
         .category .puzzle-entry .cell.extract { background-color: #ffffff80; }
@@ -47,7 +47,7 @@
             #pic4 { max-height: 200px; margin-top: -20px; }
             #pic5 { max-width: 320px; margin-top: -20px; }
             .card { width: 250px; border-radius: 8px 8px; }
-            .puzzle-entry { --cell-size: 25px; }
+            .puzzle-entry { --puzzle-cell-size: 25px; }
             .puzzle-entry .cell { background: white; }
             .category .puzzle-entry .cell.extract { background-color: white; }
             .puzzle-entry.final .cell.extract { background-color: white; }

--- a/demos/pictionary/index.html
+++ b/demos/pictionary/index.html
@@ -18,7 +18,8 @@
         .card { width: 300px; border: 1px solid black; border-radius: 10px 10px; display: flex; flex-direction: column; align-items: center; }
         .category .puzzle-entry { margin: 5px; }
         .puzzle-entry table { margin: 0px; }
-        .puzzle-entry .cell { width: 30px; height: 30px; font-size: 20px; }
+        .puzzle-entry { --cell-size: 30px; }
+        .puzzle-entry .cell { font-size: 20px; }
         .puzzle-entry .cell use { stroke: #00000080; }
         .category .puzzle-entry .cell.extract { background-color: #ffffff80; }
         .card .title { text-align: center; font-family: 'Times New Roman', Times, serif; font-size: 36px; margin-top: 20px; font-weight: bold; text-decoration: underline; }
@@ -46,7 +47,8 @@
             #pic4 { max-height: 200px; margin-top: -20px; }
             #pic5 { max-width: 320px; margin-top: -20px; }
             .card { width: 250px; border-radius: 8px 8px; }
-            .puzzle-entry .cell { width: 25px; height: 25px; background: white; }
+            .puzzle-entry { --cell-size: 25px; }
+            .puzzle-entry .cell { background: white; }
             .category .puzzle-entry .cell.extract { background-color: white; }
             .puzzle-entry.final .cell.extract { background-color: white; }
             .card .title { font-size: 24px; margin-top: 14px; }

--- a/demos/puzzle-js-demo.html
+++ b/demos/puzzle-js-demo.html
@@ -46,8 +46,8 @@
 
             .wordsearch-example .cell[data-spoke-code]:not([data-spoke-code="0"]) { background: lightgray; }
 
-            .spokes-example { --cell-size: 60px; }
-            .spokes-example .cell { text-shadow: none; color: white; }
+            .spokes-example { --puzzle-cell-size: 60px; }
+            .spokes-example .cell { text-shadow: none; color: white; font-size: 32px; }
             .spokes-example .cell .text { transform: translate(0px, -2px); }
             .spokes-example .cell::before { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); content:""; width: 40px; height: 40px; border-radius: 20px; background: black; }
 

--- a/demos/puzzle-js-demo.html
+++ b/demos/puzzle-js-demo.html
@@ -46,7 +46,8 @@
 
             .wordsearch-example .cell[data-spoke-code]:not([data-spoke-code="0"]) { background: lightgray; }
 
-            .spokes-example .cell { height: 60px; width: 60px; text-shadow: none; color: white; }
+            .spokes-example { --cell-size: 60px; }
+            .spokes-example .cell { text-shadow: none; color: white; }
             .spokes-example .cell .text { transform: translate(0px, -2px); }
             .spokes-example .cell::before { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); content:""; width: 40px; height: 40px; border-radius: 20px; background: black; }
 

--- a/demos/snakes-and-ladders/index.html
+++ b/demos/snakes-and-ladders/index.html
@@ -31,7 +31,7 @@
         }
 
         .puzzle-entry.snakes-and-ladders {
-            --cell-size: 50px;
+            --puzzle-cell-size: 50px;
         }
 
         .puzzle-entry.snakes-and-ladders .cell {

--- a/demos/snakes-and-ladders/index.html
+++ b/demos/snakes-and-ladders/index.html
@@ -30,9 +30,11 @@
             position: absolute;
         }
 
+        .puzzle-entry.snakes-and-ladders {
+            --cell-size: 50px;
+        }
+
         .puzzle-entry.snakes-and-ladders .cell {
-            width: 50px;
-            height: 50px;
             font-size: 20px;
         }
 

--- a/demos/twister/index.html
+++ b/demos/twister/index.html
@@ -24,9 +24,11 @@
             min-width: 600px;
         }
 
+        .puzzle-entry.twister {
+            --cell-size: 60px;
+        }
+
         .puzzle-entry.twister .cell {
-            width: 60px;
-            height: 60px;
             font-size: 24px;
         }
 

--- a/demos/twister/index.html
+++ b/demos/twister/index.html
@@ -25,7 +25,7 @@
         }
 
         .puzzle-entry.twister {
-            --cell-size: 60px;
+            --puzzle-cell-size: 60px;
         }
 
         .puzzle-entry.twister .cell {

--- a/puzzlejs/puzzle.css
+++ b/puzzlejs/puzzle.css
@@ -26,23 +26,23 @@
     user-select: none;
 }
 
-.puzzle-entry {
-    --cell-size: 40px;
+:root {
+    --puzzle-cell-size: 40px;
 }
 
 .puzzle-entry tr {
     display: block;
-    height: var(--cell-size);
+    height: var(--puzzle-cell-size);
 }
 
 .puzzle-entry td {
-    width: var(--cell-size);
-    height: var(--cell-size);
+    width: var(--puzzle-cell-size);
+    height: var(--puzzle-cell-size);
     padding: 0px;
     position: relative;
     background: transparent;
     text-align: center;
-    font-size: 32px;
+    font-size: calc(var(--puzzle-cell-size) * 0.8);
     font-weight: bold;
     font-family: monospace;
     border: none;
@@ -148,7 +148,7 @@
     left: 2px;
     z-index: 3;
     text-align: left;
-    font-size: 12px;
+    font-size: calc(var(--puzzle-cell-size) * 0.3);
     text-shadow: none;
     color: black;
     font-weight: normal;
@@ -161,7 +161,7 @@
     right: 2px;
     z-index: 3;
     text-align: right;
-    font-size: 12px;
+    font-size: calc(var(--puzzle-cell-size) * 0.3);
     text-shadow: none;
     color: black;
     font-weight: normal;
@@ -169,7 +169,7 @@
 }
 
 .puzzle-entry .small-text {
-    font-size: 12px;
+    font-size: calc(var(--puzzle-cell-size) * 0.3);
 }
 
 .puzzle-entry td.extract {
@@ -227,6 +227,10 @@
 .puzzle-entry .reticle-front {
     stroke-width: 1px;
     stroke: lightblue;
+}
+
+.commands {
+    margin: 0px auto;
 }
 
 .puzzle-commands {

--- a/puzzlejs/puzzle.css
+++ b/puzzlejs/puzzle.css
@@ -26,9 +26,18 @@
     user-select: none;
 }
 
+.puzzle-entry {
+    --cell-size: 40px;
+}
+
+.puzzle-entry tr {
+    display: block;
+    height: var(--cell-size);
+}
+
 .puzzle-entry td {
-    width: 40px;
-    height: 40px;
+    width: var(--cell-size);
+    height: var(--cell-size);
     padding: 0px;
     position: relative;
     background: transparent;

--- a/puzzlejs/puzzle.js
+++ b/puzzlejs/puzzle.js
@@ -1530,6 +1530,8 @@ function PuzzleEntry(p, index) {
         for (var i = 0; i < this.leftClueDepth; i++) { row.insertCell(-1); }
         var cell = row.insertCell(-1);
         cell.style.maxWidth = table.offsetWidth * this.numCols / (this.numCols + this.leftClueDepth + this.rightClueDepth);
+        cell.style.margin = "0px auto";
+        cell.style.display = "block";
         cell.colSpan = this.numCols;
         cell.insertBefore(this.commands, null);
         for (var i = 0; i < this.rightClueDepth; i++) { row.insertCell(-1); }

--- a/reference/reference-styling.html
+++ b/reference/reference-styling.html
@@ -40,9 +40,7 @@
 
             .basic-text-example .cell { color: red; font-style: italic; font-family:'Times New Roman', Times, serif; }
 
-            .big-example { --cell-size: 80px; font-size: 64px; }
-            .big-example .cell { font-size: 64px; }
-            .big-example .cell.small-text { font-size: 20px; }
+            .big-example { --puzzle-cell-size: 80px; }
 
             .outline-text-example .cell { background: yellow; color: red; text-shadow: none; }
 
@@ -118,7 +116,7 @@
         </div>
 
         <h2>Size</h2>
-        <p>Cell size can currently be changed simply by setting the CSS variable <code>--cell-size</code> on a puzzle. If the cells contain text, you may also want to change the <code>font-size</code> property, as well as for small text.</p>
+        <p>Cell size can currently be changed simply by setting the CSS variable <code>--puzzle-cell-size</code> on a puzzle. If the cells contain text, you may also want to change the <code>font-size</code> property to increase or decrease the font size, as well as for <code>.small-text</code>. That said, font sizes will scale by default along with cell size.</p>
         <div class="example">
             <div class="puzzle-entry big-example" data-text="bi|g."></div>
         </div>
@@ -255,10 +253,10 @@
         </div>
 
         <h2>CSS Variables</h2>
-        <p>These CSS variables can be set in a CSS rule on a puzzle.</p>
+        <p>These CSS variables can be set in a CSS rule on a puzzle. The CSS rules may also be <a href="https://www.w3schools.com/css/css3_variables_javascript.asp" target="_blank">modified through JavaScript</a>.</p>
         <table class="reference-table">
             <tr><th>Variable</th><th>Meaning</th></tr>
-            <tr><td><code>--cell-size</code></td><td>The size of a single cell of the grid. This variable will control both the cell height and the cell width. If you want cells to be rectangular, set the CSS <code>width</code> property in a rule with the <code>.puzzle-entry .cell</code> selector as well as setting the <code>--cell-size</code> variable in a rule with the <code>.puzzle-entry</code> selector.</td></tr>
+            <tr><td><code>--puzzle-cell-size</code></td><td>The size of a single cell of the grid. This variable will control both the cell height and the cell width. If you want cells to be rectangular, set the CSS <code>width</code> property in a rule with the <code>.puzzle-entry .cell</code> selector as well as setting the <code>--puzzle-cell-size</code> variable in a rule with the <code>.puzzle-entry</code> selector.</td></tr>
         </table>
 
         <h2>Many Helpful CSS Selectors</h2>
@@ -305,6 +303,6 @@
         </table>
 
         <h2 id="BreakingChanges">Breaking Changes</h2>
-        <p>Cell sizing is now controlled best from a <code>--cell-size</code> CSS variable set on the puzzle, rather than by the <code>width</code> and <code>height</code> properties of a cell.</p>
+        <p>Cell sizing is now controlled best from a <code>--puzzle-cell-size</code> CSS variable set on the puzzle, rather than by the <code>width</code> and <code>height</code> properties of a cell.</p>
     </body>
 </html>

--- a/reference/reference-styling.html
+++ b/reference/reference-styling.html
@@ -34,9 +34,14 @@
                 background: white;
             }
 
+            .reference-table td:first-child {
+                min-width: 150px;
+            }
+
             .basic-text-example .cell { color: red; font-style: italic; font-family:'Times New Roman', Times, serif; }
 
-            .big-example .cell { width: 80px; height: 80px; font-size: 64px; }
+            .big-example { --cell-size: 80px; font-size: 64px; }
+            .big-example .cell { font-size: 64px; }
             .big-example .cell.small-text { font-size: 20px; }
 
             .outline-text-example .cell { background: yellow; color: red; text-shadow: none; }
@@ -113,7 +118,7 @@
         </div>
 
         <h2>Size</h2>
-        <p>Cell size can currently be changed simply by setting <code>width</code> and <code>height</code> on a cell. If the cell contains text, you may also want to change the <code>font-size</code> property, as well as for small text.</p>
+        <p>Cell size can currently be changed simply by setting the CSS variable <code>--cell-size</code> on a puzzle. If the cells contain text, you may also want to change the <code>font-size</code> property, as well as for small text.</p>
         <div class="example">
             <div class="puzzle-entry big-example" data-text="bi|g."></div>
         </div>
@@ -249,9 +254,16 @@
 </div>
         </div>
 
+        <h2>CSS Variables</h2>
+        <p>These CSS variables can be set in a CSS rule on a puzzle.</p>
+        <table class="reference-table">
+            <tr><th>Variable</th><th>Meaning</th></tr>
+            <tr><td><code>--cell-size</code></td><td>The size of a single cell of the grid. This variable will control both the cell height and the cell width. If you want cells to be rectangular, set the CSS <code>width</code> property in a rule with the <code>.puzzle-entry .cell</code> selector as well as setting the <code>--cell-size</code> variable in a rule with the <code>.puzzle-entry</code> selector.</td></tr>
+        </table>
+
         <h2>Many Helpful CSS Selectors</h2>
         <p>This is certainly not an exhaustive list of selectors, but it includes nearly all classes that PuzzleJS sets on output elements.</p>
-        <table>
+        <table class="reference-table">
             <tr><th>Selector</th><th>Selects</th></tr>
             <tr><td><code>.cell</code></td><td>A cell of the puzzle grid: interior, exterior, etc.</td></tr>
             <tr><td><code>.cell.inner-cell</code></td><td>A cell of the main (interior) area of the puzzle grid.</td></tr>
@@ -293,6 +305,6 @@
         </table>
 
         <h2 id="BreakingChanges">Breaking Changes</h2>
-        <p>There are no breaking changes to styling at this time.</p>
+        <p>Cell sizing is now controlled best from a <code>--cell-size</code> CSS variable set on the puzzle, rather than by the <code>width</code> and <code>height</code> properties of a cell.</p>
     </body>
 </html>


### PR DESCRIPTION
Advantages to this approach:
- only need to specify size once
- puzzle.css can set the height on the tr as well, solving layout issues
- better prepared for hex grids