### PR TITLE
Tabstop for each PuzzleGrid

### DIFF
--- a/puzzlejs/puzzle.js
+++ b/puzzlejs/puzzle.js
@@ -1378,6 +1378,7 @@ function PuzzleGrid(puzzleEntry, options, container, puzzleId) {
     this.tilt = 0;
     this.stateDirty = false;
     this.inhibitSave = false;
+    this.tabstopGrid = null;
 
     this.parseOuterClues = function(clues) {
         var clueDepth = 0;
@@ -1920,8 +1921,9 @@ function PuzzleGrid(puzzleEntry, options, container, puzzleId) {
 
             if (!td.classList.contains("unselectable")) {
                 if (allowInput) {
-                    td.tabIndex = this.puzzleEntry.firstCenterFocus ? -1 : 0;
+                    td.tabIndex = (this.puzzleEntry.firstCenterFocus && this.tabstopGrid) ? -1 : 0;
                     if (!this.puzzleEntry.firstCenterFocus) { this.puzzleEntry.firstCenterFocus = td; }
+                    if (!this.tabstopGrid) { this.tabstopGrid = td; }
                     td.addEventListener("keydown",  e => { this.puzzleEntry.keyDown(e); });
                     td.addEventListener("beforeinput", e => { this.puzzleEntry.beforeInput(e); });
                     td.addEventListener("pointerdown",  e => { this.puzzleEntry.pointerDown(e); });


### PR DESCRIPTION
Previously had tabstop only for first grid if multiple puzzle-grid DIVs in a puzzle-entry DIV.