### PR TITLE
Skip filled, keyboard nav, set advance direction

### DIFF
--- a/puzzlejs/puzzle.js
+++ b/puzzlejs/puzzle.js
@@ -466,7 +466,7 @@ function PuzzleEntry(p, index) {
     this.jumpToNearGrid = function(td, drow, dcol) {
         let rcActive = this.activeGrid.grid.getBoundingClientRect();
         let igridBest = -1;
-        let dzBest = 99999;
+        let dzBest = Infinity;
         let puzzleGrid;
 
         for (let igrid = 0; igrid < this.puzzleGrids.length; ++igrid) {
@@ -483,17 +483,17 @@ function PuzzleEntry(p, index) {
         let xActive = (rcActive.left + rcActive.right) / 2;
         let yActive = (rcActive.top + rcActive.bottom) / 2;
         puzzleGrid = this.puzzleGrids[igridBest];
-        dzBest = 9999999;
+        dzBest = Infinity;
         let tdBest = null;
-        for (let cell in puzzleGrid.lookup) {
-            let td, rc;
-            if ((td = puzzleGrid.lookup[cell]) && (rc = td.getBoundingClientRect())) {
+        puzzleGrid.container.querySelectorAll(".inner-cell").forEach(td => {
+            let rc;
+            if (td && (rc = td.getBoundingClientRect())) {
                 let x = (rc.left + rc.right) / 2;
                 let y = (rc.top + rc.bottom) / 2;
                 let dz = Math.abs(x - xActive) ** 2 + Math.abs(y - yActive) ** 2;
                 if (dz >= 0 && dz < dzBest) { dzBest = dz; tdBest = td; }
             }
-        }
+        });
         if (!tdBest)
             return false;
 
@@ -727,8 +727,9 @@ function PuzzleEntry(p, index) {
                 if (this.activeGrid.options["data-text-advance-on-type"] && this.activeGrid.options["data-text-advance-style"] != "wrap" && this.activeGrid.numCols > 1 && this.activeGrid.numRows > 1) { this.setDxDy(1 - this.dx, 1 - this.dy); dirToggled = true; }
                 if (this.activeGrid.options["data-clue-locations"]) { this.unmark(e.target); this.mark(e.target); }
                 if (e.currentTarget.classList.contains("given-fill")) return;
-                if (this.activeGrid.options["data-fill-cycle"]) { this.currentFill = this.cycleClasses(e.target, "class-fill", this.activeGrid.fillClasses, e.shiftKey); }
-                if (!dirToggled && !this.currentFill) {
+                if (this.activeGrid.options["data-fill-cycle"] && this.activeGrid.fillClasses.length > 1) {
+                    if (!e.currentTarget.classList.contains("given-fill")) { this.currentFill = this.cycleClasses(e.target, "class-fill", this.activeGrid.fillClasses, e.shiftKey); }
+                } else if (!dirToggled) {
                     this.setText(e.target, "", e.target.classList.contains("small-text"));
                     if (this.activeGrid.options["data-text-advance-on-type"])
                         this.move(e.target, this.dy, this.dx);

--- a/puzzlejs/puzzle.js
+++ b/puzzlejs/puzzle.js
@@ -727,7 +727,7 @@ function PuzzleEntry(p, index) {
                 if (this.activeGrid.options["data-text-advance-on-type"] && this.activeGrid.options["data-text-advance-style"] != "wrap" && this.activeGrid.numCols > 1 && this.activeGrid.numRows > 1) { this.setDxDy(1 - this.dx, 1 - this.dy); dirToggled = true; }
                 if (this.activeGrid.options["data-clue-locations"]) { this.unmark(e.target); this.mark(e.target); }
                 if (e.currentTarget.classList.contains("given-fill")) return;
-                if (this.activeGrid.options["data-fill-cycle"] && this.activeGrid.fillClasses.length > 1) {
+                if (this.activeGrid.options["data-fill-cycle"] && this.activeGrid.fillClasses && this.activeGrid.fillClasses.length > 1) {
                     if (!e.currentTarget.classList.contains("given-fill")) { this.currentFill = this.cycleClasses(e.target, "class-fill", this.activeGrid.fillClasses, e.shiftKey); }
                 } else if (!dirToggled) {
                     this.setText(e.target, "", e.target.classList.contains("small-text"));


### PR DESCRIPTION
* New option `data-text-advance-skip-filled` for controlling whether text entry skips over already-filled cells. This will skip to next blank; if there are no blanks, will move to next valid space (as before). Default is false; set true for modes that set advance-on-type (crossword, linear, 2 crostic).
* Arrow will jump between puzzle-grids in the same puzzle-entry. Algorithm: choose grid that's closest in target direction, then choose cell that's geometrically closest (so can handle jagged edges). New `jumpToNearGrid` and `dzDistanceToRect` functions.
* Use space to clear cell (when advance-style != crossword); essentially equivalent to Del + arrow.
* Jump to appropriate grid edge on Home, End, PgUp, PgDn. New `moveToEdge` function.
* Text-advance direction (H/V) is toggled when click to select a cell that can go only in the non-currrent direction. I thought about whether to perform this check when arrow (or text-advance) to a cell, and decided that it shouldn't. In those scenarios, the direction is likely to be correct from arrowing, and if it's not, the user probably isn't entering words (maybe just picking up missing solo chars). Clicking on the current cell (or using space) will toggle direction as before; they're not prevented from getting into the weird direction; this just assists in getting into the 'right' direction automatically. New `canAdvance` function (and 2 wrappers).
* Fix: don't toggle advance direction if ctrl-click to mark interesting.